### PR TITLE
Fixed py3k stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: python
+
 python:
-  - "2.5"
-  - "2.6"
   - "2.7"
-#  - "3.2"
-  - "pypy"
+
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py32
+  - TOXENV=pypy
+
 install:
-  - pip install . --use-mirrors
-script: python src/mimerender.py
+    - pip install tox
+
+# command to run tests
+script:
+    - tox

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+	'Programming Language :: Python :: 3'
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     py_modules=['mimerender'],
     package_dir={'':'src'},
-    requires=['mimeparse'],
-    install_requires=['mimeparse'],
+    install_requires=['python_mimeparse >= 0.1.4'],
 )

--- a/src/mimerender.py
+++ b/src/mimerender.py
@@ -72,7 +72,7 @@ def _get_mime_types(shortname):
         raise MimeRenderException('No known mime types for "%s"'%shortname)
 
 def _get_short_mime(mime):
-    for shortmime, mimes in _MIME_TYPES.items():
+    for shortmime, mimes in list(_MIME_TYPES.items()):
         if mime in mimes:
             return shortmime
     raise MimeRenderException('No short mime for type "%s"' % mime)
@@ -148,7 +148,7 @@ class MimeRenderBase(object):
         
         supported = list()
         renderer_dict = dict()
-        for shortname, renderer in renderers.items():
+        for shortname, renderer in list(renderers.items()):
             for mime in _get_mime_types(shortname):
                 supported.append(mime)
                 renderer_dict[mime] = renderer
@@ -162,7 +162,7 @@ class MimeRenderBase(object):
             default_mime = default_mimes[0]
             default_renderer = get_renderer(default_mime)
         else:
-            default_mime, default_renderer = renderer_dict.items()[0]
+            default_mime, default_renderer = list(renderer_dict.items())[0]
         
         def wrap(target):
             @wraps(target)
@@ -195,12 +195,12 @@ class MimeRenderBase(object):
                         mimerender_shortmime=shortmime,
                         mimerender_mime=mime,
                         mimerender_renderer=renderer)
-                for key, value in context_vars.items():
+                for key, value in list(context_vars.items()):
                     self._set_context_var(key, value)
                 try:
                     result = target(*args, **kwargs)
                 finally:
-                    for key in context_vars.keys():
+                    for key in list(context_vars.keys()):
                         self._clear_context_var(key)
                 content_type = mime
                 if charset: content_type += '; charset=%s' % charset
@@ -229,7 +229,7 @@ class MimeRenderBase(object):
             def wrapper(*args, **kwargs):
                 try:
                     return target(*args, **kwargs)
-                except BaseException, e:
+                except BaseException as e:
                     for klass, status in mapping:
                         if isinstance(e, klass):
                             return helper(e, status)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = py26,py27,py32,pypy
+
+[testenv]
+
+[testenv:py26]
+basepython = python2.6
+commands = {envpython} src/mimerender.py
+
+[testenv:py27]
+basepython = python2.7
+commands = {envpython} src/mimerender.py
+
+[testenv:py32]
+basepython = python3.2
+commands = {envpython} src/mimerender.py
+
+[testenv:pypy]
+basepython = pypy
+commands = {envpython} src/mimerender.py


### PR DESCRIPTION
to setup virtualenv properly in order to do the unittest under py3k.

Also, it seems that python25 is not happy with setuptools in setup.py
Remove the testing of python25.

The following is some warning when testing under py3k, you may want to fix it later.

src/mimerender.py:450: DeprecationWarning: Please use assertEqual instead.
50  decorated_function.**name**)
51..src/mimerender.py:526: DeprecationWarning: Please use assertNotEqual instead.
52  self.assertNotEquals(mimerender.status, '200 OK')
