### PR TITLE
Removes custom response code from Flask implementation

### DIFF
--- a/src/mimerender.py
+++ b/src/mimerender.py
@@ -330,11 +330,7 @@ try:
             del flask.request.environ[key]
 
         def _make_response(self, content, headers, status):
-            response = flask.make_response(content)
-            response.status = status
-            for k, v in headers:
-                response.headers[k] = v
-            return response
+            return flask.make_response(content, status, headers)
 
 except ImportError:
     pass


### PR DESCRIPTION
Uses Flask's built-in `make_response()` function to return a response object. This fixes a bug that occurred when a Flask view function returns a status code as an integer (like `200`) as opposed to a string (like `'200 OK'`).
