### PR TITLE
Fix the tests

### DIFF
--- a/src/mimerender.py
+++ b/src/mimerender.py
@@ -34,8 +34,11 @@ KML   = 'kml'
 KMZ   = 'kmz'
 MSGPACK = 'msgpack'
 
+# Map of mime categories to specific mime types. The first mime type in each
+# category's tuple is the default one (e.g. the default for XML is
+# application/xml).
 _MIME_TYPES = {
-    XML:   ('application/xml', 'text/xml', 'application/x-xml',),
+    XML:   ('text/xml', 'application/xml', 'application/x-xml'),
     JSON:  ('application/json',),
     JSONLD: ('application/ld+json',),
     JSONP: ('application/javascript',),
@@ -188,7 +191,11 @@ class MimeRenderBase(object):
             default_mime = default_mimes[0]
             default_renderer = get_renderer(default_mime)
         else:
-            default_mime, default_renderer = next(iter(renderer_dict.items()))
+            # pick the first mime category from the `renderers` dict (note:
+            # this is only deterministic if len(`renderers`) == 1) and the
+            # default mime type/renderer for a given mime category.
+            default_mime = _get_mime_types(next(iter(renderers.keys())))[0]
+            default_renderer = renderer_dict[default_mime]
 
         def wrap(target):
             @wraps(target)

--- a/src/test.py
+++ b/src/test.py
@@ -41,8 +41,8 @@ class MimeRenderTests(unittest.TestCase):
     def test_single_variant(self):
         mimerender = TestMimeRender()
         result = mimerender(
-                xml=lambda x: '<xml>%s</xml>' % x
-                )(lambda: dict(x='test'))()
+                xml=lambda x: '<xml>%s</xml>' % x,
+            )(lambda: dict(x='test'))()
         self.assertEqual(mimerender.headers['Content-Type'], 'text/xml')
         self.assertEqual(result, '<xml>test</xml>')
 

--- a/src/test.py
+++ b/src/test.py
@@ -38,10 +38,19 @@ class TestMimeRender(mimerender.MimeRenderBase):
 
 
 class MimeRenderTests(unittest.TestCase):
-    def test_single_variant(self):
+    def test_single_variant_without_default(self):
         mimerender = TestMimeRender()
         result = mimerender(
                 xml=lambda x: '<xml>%s</xml>' % x,
+            )(lambda: dict(x='test'))()
+        self.assertEqual(mimerender.headers['Content-Type'], 'text/xml')
+        self.assertEqual(result, '<xml>test</xml>')
+
+    def test_single_variant_with_default(self):
+        mimerender = TestMimeRender()
+        result = mimerender(
+                xml=lambda x: '<xml>%s</xml>' % x,
+                default='xml'
             )(lambda: dict(x='test'))()
         self.assertEqual(mimerender.headers['Content-Type'], 'text/xml')
         self.assertEqual(result, '<xml>test</xml>')


### PR DESCRIPTION
By having a clearer, consistent, and documented logic for picking a default mime type based on a given mime category.

In the past, it was consistent if you specified the default mime category, but it was non-deterministic if you didn't specify the default. For example, prior to this PR:

`mimerender(xml=lambda x: '<xml>%s</xml>' % x, default='xml')` would always default to `application/xml`.
`mimerender(xml=lambda x: '<xml>%s</xml>' % x)` would _sometimes_ default to `application/xml`, sometimes to `text/xml', and sometimes to`application/x-xml`.

I improved it so that it always picks the first mime type from the mime types list for a given mime category. I also changed the default mime type for XML to `text/xml`, because it seems saner to me. It's a backward incompatible change though, so let me know if you'd prefer to default to `application/xml` (your tests suggested that you preferred `text/xml` though).
